### PR TITLE
Add js_of_ocaml stub with overlay demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,7 @@
 *~
+*.byte
+*.cmi
+*.cmo
+*.html
+*.js
+*.map

--- a/README.md
+++ b/README.md
@@ -6,6 +6,25 @@ E.g.:
 ```
 $ utop
 ...
-utop # #use "dwarf-locstack.ml";;
+utop # #use "dwarf_locstack.ml";;
 ...
+```
+
+## HTML+JS
+
+The `dwarf_locstack_js.ml` module and `dwarf_locstack.html.in` document are
+linked via [`js_of_ocaml`](https://github.com/ocsigen/js_of_ocaml) to form an
+interactive and graphical interface to experiment with the locstack
+implementation.
+
+E.g.:
+
+```
+$ opam install js_of_ocaml js_of_ocaml-ppx
+$ ./build_html.sh debug   # debug mode generates separate .js and .map
+$ # or
+$ ./build_html.sh release # release mode inlines the js into the .html document
+                          # resulting in a single self-contained file that
+                          # can be copied around and loaded directly in a browser
+$ xdg-open dwarf_locstack.html
 ```

--- a/build_html.sh
+++ b/build_html.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+-() { exit 1; }
+usage() { printf 'usage: %s [debug|release]\n' "$0"; -; }
+
+cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" ||-
+
+(($# == 1)) || usage
+
+case "$1" in
+debug)
+    js_of_ocaml_flags=(--pretty --no-inline --source-map --debug-info)
+    awk_script='{ print }'
+    ;;
+release)
+    js_of_ocaml_flags=()
+    awk_script='
+        /^<script/ {
+            print "<script type=\"module\">"
+            while (getline line < "dwarf_locstack.js") {
+                print line
+            }
+            print "</script>"
+            next
+        }
+        { print }
+    '
+    ;;
+*) usage;;
+esac
+
+ocamlfind ocamlc -package js_of_ocaml -package js_of_ocaml-ppx \
+    -linkpkg -g -o dwarf_locstack_js.byte \
+    dwarf_locstack.ml dwarf_locstack_js.ml ||-
+js_of_ocaml "${js_of_ocaml_flags[@]}" \
+    -o dwarf_locstack.js dwarf_locstack_js.byte ||-
+
+awk "$awk_script" dwarf_locstack.html.in >dwarf_locstack.html ||-

--- a/dwarf_locstack.html.in
+++ b/dwarf_locstack.html.in
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8" />
+<title>DW_OP_overlay playground</title>
+<style>
+html {
+    font-family: Calibri, sans-serif;
+}
+.center {
+    margin-left: auto;
+    margin-right: auto;
+    padding: 1% 5%;
+}
+input[type="range"] {
+    width: 100%;
+}
+.box {
+    border: 1px solid black;
+    height: 1em;
+    display: inline-block;
+    position: relative;
+}
+.box > span {
+    writing-mode: vertical-lr;
+    position: absolute;
+    top: 1.1em;
+}
+</style>
+</head>
+<body>
+<div class="center">
+    <label for="overlay_offset_in">Overlay Offset:</label>
+    <input id="overlay_offset_in" name="overlay_offset_in" type="range" min="0" max="32">
+    <label for="overlay_size_in">Overlay Size:</label>
+    <input id="overlay_size_in" name="overlay_size_in" type="range" min="0" max="32">
+    <div id="out"></div>
+</div>
+</body>
+<script src="dwarf_locstack.js"></script>
+</html>

--- a/dwarf_locstack_js.ml
+++ b/dwarf_locstack_js.ml
@@ -1,0 +1,51 @@
+open Dwarf_locstack
+open Js_of_ocaml
+open Dom_html
+open Printf
+
+(* Shorthand for coerced getElementById with assertion *)
+let get id coerce_to = Option.get (getElementById_coerce id coerce_to)
+
+let html_of_part (s, e, loc) = sprintf
+  {|<div class="box" style="width: %nem;"><span>%s</span></div>|}
+  (e - s) (string_of_location loc)
+
+let _ =
+  let overlay_offset_in = get "overlay_offset_in" CoerceTo.input in
+  let overlay_size_in = get "overlay_size_in" CoerceTo.input in
+  let out = get "out" CoerceTo.element in
+  let render _ =
+    let overlay_offset = (Js.parseInt overlay_offset_in##.value) in
+    let overlay_size = (Js.parseInt overlay_size_in##.value) in
+    let overlay_locexpr = [DW_OP_reg 1;
+                           DW_OP_reg 2;
+                           DW_OP_const overlay_offset;
+                           DW_OP_const overlay_size;
+                           DW_OP_overlay] in
+    let (storage, offset) = eval_to_loc overlay_locexpr context in
+    (*TODO: string_of_locexpr? *)
+    let expr_text = sprintf "\
+        DW_OP_reg 1;\n\
+        DW_OP_reg 2;\n\
+        DW_OP_const %n;\n\
+        DW_OP_const %n;\n\
+        DW_OP_overlay;\
+      " overlay_offset overlay_size in
+    let boxes_html =
+      match storage with
+      | Composite(parts) -> String.concat "" (List.map html_of_part (sort_parts parts))
+      | _ -> "" in
+    let out_html =
+      sprintf "\
+          <div>Evaluating:</div>\n\
+          <pre>%s</pre>\n\
+          <div>Yields:</div>\n\
+          <pre>%s</pre>\n\
+          <div>%s</div>\
+        " expr_text (string_of_storage storage) boxes_html in
+    out##.innerHTML := Js.string out_html;
+    Js._true in
+  ignore (addEventListener overlay_offset_in Event.input (handler render) Js._false);
+  ignore (addEventListener overlay_size_in Event.input (handler render) Js._false);
+  (* Initial render for when page first loads *)
+  render ()


### PR DESCRIPTION
This seemed like the path of least resistance to get an interactive interface, both in terms of implementing it in and/or interfacing it with the ocaml and in terms of sharing the result.

The included demo is pretty bare-bones, but I think still useful to explore corner cases quickly.

I renamed the main dwarf-locstack.ml file because the ocaml bytecode compiler was complaining that it didn't have a corresponding module identifier. I don't have a ton of experience with ocaml so if there's a better way to address this I can undo that change.