### PR TITLE
Add a preprocessor to simplify the input syntax

### DIFF
--- a/js/dwarf_locstack.html.in
+++ b/js/dwarf_locstack.html.in
@@ -20,8 +20,6 @@ button {
 }
 footer {
     color: gray;
-    margin-top: 2em;
-    border-top: 1px solid gray;
 }
 </style>
 </head>
@@ -33,12 +31,37 @@ footer {
     <textarea id="input" rows="16" cols="80"
         autocapitalize="false" autocomplete="false" autocorrect="false"
         autofocus="true" required="true" spellcheck="false" wrap="off"
-        placeholder="; Expression to evaluate:&#10;(DW_OP_reg 4)&#10;(DW_OP_const 1)&#10;DW_OP_offset&#10;; ..."></textarea>
+        placeholder="; Expression to evaluate:&#10;DW_OP_reg 4&#10;DW_OP_const 1&#10;DW_OP_offset&#10;; ..."></textarea>
     <div><button id="eval">Evaluate</button></div>
+    <h2>Preprocessed Input:</h2>
+    <pre id="preprocessed"></pre>
     <h2>Result:</h2>
     <pre id="output"></pre>
+    <hr style="margin-top: 2em;">
+    <h2>Notes</h2>
+    <h3>Source</h3>
+    <p>
+    This is generated from Baris' interpreter at
+    <a href="https://github.com/barisaktemur/dwarf-locstack/blob/main/dwarf_locstack.ml">barisaktemur/dwarf-locstack</a>
+    using <a href="https://github.com/ocsigen/js_of_ocaml">ocsigen/js_of_ocaml</a>.
+    The set of implemented operations is the same as the set of constructors for <tt>type dwarf_op</tt> there.
+    </p>
+    <h3>Input Syntax</h3>
+    <p>
+    The (simplified) input format is one DWARF operation per line, with
+    space-delimited parameters. Comments begin with <tt>;</tt> and extend to
+    the end of the line.
+    </p>
+    <p>
+    The full expression syntax is just an <tt>sexp</tt> list as described at
+    <a href="https://github.com/janestreet/sexplib">janestreet/sexplib</a>.
+    A preprocessor implements the simplified format and generates the canonical
+    <tt>sexp</tt> form. If any non-comment parenthesis character (either
+    "<tt>(</tt>" or "<tt>)</tt>") is present the preprocessor is disabled.
+    </p>
+    <hr>
     <footer>
-        Built from <code>GIT_REVISION</code> at <code>CURRENT_TIME</code>
+    <p>Built from <code>GIT_REVISION</code> at <code>CURRENT_TIME</code></p>
     </footer>
 </div>
 </body>

--- a/js/dwarf_locstack_js.ml
+++ b/js/dwarf_locstack_js.ml
@@ -6,21 +6,63 @@ open Sexplib
 (* Shorthand for coerced getElementById with assertion *)
 let get id coerce_to = Option.get (getElementById_coerce id coerce_to)
 
+(* Get the non-empty, non-comment part of line, or None if it doesn't exist *)
+let noncomment_part line =
+  List.nth_opt (String.split_on_char ';' line) 0
+  |> Option.map String.trim
+  |> function | Some "" -> None | s -> s
+
+(*
+  Heuristically "Sexp-ify" the input.
+
+  Goal: reduce noise for the common case by allowing the user to elide parens
+  around non-0-ary constructors, and around the top-level list of op
+  constructors.
+
+  Approach:
+
+    First, remove comments.
+
+    Then, if the remaining input contains no parenthesis, surround any lines containing spaces with parens.
+
+    Finally, surround everything in a top-level set of parens.
+
+  Note: To avoid ambiguity in the case of all 0-ary constructors this means we
+  need to require each constructor and its arguments appear on one line, and
+  that each constructors be on a different line.
+ *)
+let preprocess input =
+  let uncommented_lines = input
+    |> String.split_on_char '\n'
+    |> List.filter_map noncomment_part in
+  let has_parens = uncommented_lines
+    |> List.exists (fun line -> let c = String.contains line in c '(' || c ')') in
+  if has_parens then
+    uncommented_lines
+    |> String.concat "\n"
+  else
+    uncommented_lines
+    |> List.map (fun s -> if String.contains s ' ' then "(" ^ s ^ ")" else s)
+    |> String.concat "\n"
+    |> (fun s -> "(" ^ s ^ ")")
+
 let _ =
   let context = get "context" CoerceTo.element in
   let input = get "input" CoerceTo.textarea in
   let eval = get "eval" CoerceTo.button in
+  let preprocessed = get "preprocessed" CoerceTo.element in
   let output = get "output" CoerceTo.element in
   context##.innerHTML := (Js.string (Sexp.to_string_hum (sexp_of_context_t Dwarf_locstack.context)));
   let render _ =
+    let locexpr_sexp_string = preprocess (Js.to_string input##.value) in
     let output_html =
       try
-        let locexpr_sexp_string = "(" ^ (Js.to_string input##.value) ^ ")" in
         let locexpr = (locexpr_t_of_sexp (Parsexp.Single.parse_string_exn locexpr_sexp_string)) in
         let result_loc = Dwarf_locstack.eval_to_loc locexpr Dwarf_locstack.context  in
         let result_loc_sexp = sexp_of_location result_loc in
         Sexp.to_string_hum result_loc_sexp
       with e -> Printexc.to_string e in
+    preprocessed##.innerHTML := Js.string locexpr_sexp_string;
     output##.innerHTML := Js.string output_html;
     Js._true in
   ignore (addEventListener eval Event.click (handler render) Js._false)


### PR DESCRIPTION
Support a simplified input syntax and add some notes to the webpage.

Note that old inputs with parens will break unless the top-level parens are added, seemed a cleaner way to handle the preprocessing (i.e. any parens being present means no preprocessing).